### PR TITLE
Optimization for business marker text

### DIFF
--- a/scripts/core.client.lua
+++ b/scripts/core.client.lua
@@ -31,34 +31,17 @@ addEventHandler("onClientRender", root,
 					dxDrawImage(screen_x - width / 2, screen_y - screen_height / 10, width, 80, "files/business.png");
 				end
 				if settings.show_business_info_on_marker then
-					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 1.4);
-					if screen_x then
-						if #tostring(id) == 1 then id = "0"..tostring(id) end
-						dxDrawFramedText("ID: #"..id, screen_x, screen_y, screen_x, screen_y, tocolor(255, 255, 255, 255), 1.0, "default-bold", "center", "center", false, false, false);
-					end
-					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 1.2);
-					if screen_x then
-						dxDrawFramedText("Name: "..name, screen_x, screen_y, screen_x, screen_y, tocolor(255, 255, 255, 255), 1.0, "default-bold", "center", "center", false, false, false);
-					end
-					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 1.0);
-					if screen_x then
-						dxDrawFramedText("Owner: "..owner, screen_x, screen_y, screen_x, screen_y, tocolor(255, 255, 255, 255), 1.0, "default-bold", "center", "center", false, false, false);
-					end
-					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 0.8);
-					if screen_x then
-						dxDrawFramedText("Cost: $"..cost, screen_x, screen_y, screen_x, screen_y, tocolor(255, 255, 255, 255), 1.0, "default-bold", "center", "center", false, false, false);
-					end
-					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 0.6);
-					if screen_x then
-						dxDrawFramedText("Payout: $"..payout, screen_x, screen_y, screen_x, screen_y, tocolor(255, 255, 255, 255), 1.0, "default-bold", "center", "center", false, false, false);
-					end
-					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 0.4);
-					if screen_x then
-						dxDrawFramedText("Payout Time: "..payout_otime.." "..payout_unit, screen_x, screen_y, screen_x, screen_y, tocolor(255, 255, 255, 255), 1.0, "default-bold", "center", "center", false, false, false);
-					end
+					local output_str = ""
 					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 0.2);
 					if screen_x then
-						dxDrawFramedText("Bank: $"..bank, screen_x, screen_y, screen_x, screen_y, tocolor(255, 255, 255, 255), 1.0, "default-bold", "center", "center", false, false, false);
+						output_str = output_str.."ID: #"..id.."\n\n"
+						output_str = output_str.."Name: "..name.."\n\n"
+						output_str = output_str.."Owner: "..owner.."\n\n"
+						output_str = output_str.."Cost: $"..convertNumber(cost).."\n\n"
+						output_str = output_str.."Payout: $"..convertNumber(payout).."\n\n"
+						output_str = output_str.."Payout Time: "..payoutOTime.." "..payoutUnit.."\n\n"
+						output_str = output_str.."Bank: $"..convertNumber(bank).."\n\n"
+						dxDrawFramedText(output_str, screen_x, screen_y, screen_x, screen_y, tocolor(255, 255, 255, 255), 1.0, "default-bold", "center", "center", false, false, false);
 					end
 				end
 			end

--- a/scripts/core.client.lua
+++ b/scripts/core.client.lua
@@ -32,7 +32,7 @@ addEventHandler("onClientRender", root,
 				end
 				if settings.show_business_info_on_marker then
 					local output_str = ""
-					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 0.5);
+					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 0.7);
 					if screen_x then
 						output_str = output_str.."ID: #"..id.."\n\n"
 						output_str = output_str.."Name: "..name.."\n\n"

--- a/scripts/core.client.lua
+++ b/scripts/core.client.lua
@@ -32,14 +32,14 @@ addEventHandler("onClientRender", root,
 				end
 				if settings.show_business_info_on_marker then
 					local output_str = ""
-					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 0.2);
+					screen_x, screen_y = getScreenFromWorldPosition(x, y, z + 0.5);
 					if screen_x then
 						output_str = output_str.."ID: #"..id.."\n\n"
 						output_str = output_str.."Name: "..name.."\n\n"
 						output_str = output_str.."Owner: "..owner.."\n\n"
 						output_str = output_str.."Cost: $"..convertNumber(cost).."\n\n"
 						output_str = output_str.."Payout: $"..convertNumber(payout).."\n\n"
-						output_str = output_str.."Payout Time: "..payoutOTime.." "..payoutUnit.."\n\n"
+						output_str = output_str.."Payout Time: "..payout_otime.." "..payout_unit.."\n\n"
 						output_str = output_str.."Bank: $"..convertNumber(bank).."\n\n"
 						dxDrawFramedText(output_str, screen_x, screen_y, screen_x, screen_y, tocolor(255, 255, 255, 255), 1.0, "default-bold", "center", "center", false, false, false);
 					end
@@ -48,6 +48,17 @@ addEventHandler("onClientRender", root,
 		end
 	end
 );
+
+function convertNumber ( number )  
+	local formatted = number  
+	while true do      
+		formatted, k = string.gsub(formatted, "^(-?%d+)(%d%d%d)", '%1,%2')    
+		if ( k==0 ) then      
+			break   
+		end  
+	end  
+	return formatted
+end
 
 addEvent("business.showInstructions", true);
 addEventHandler("business.showInstructions", root,

--- a/scripts/core.server.lua
+++ b/scripts/core.server.lua
@@ -1,8 +1,10 @@
 local _settings = get("");
 local settings = {};
-for k, v in pairs(_settings) do
-	k = split(k, ".")[2];
-	settings[k] = v;
+if _settings then
+	for k, v in pairs(_settings) do
+		k = split(k, ".")[2];
+		settings[k] = v;
+	end
 end
 
 if (settings.key:len() < 1 or settings.key:len() > 1) then


### PR DESCRIPTION
Original pull request: #6 

Take a look at the result:

![mta-screen_2015-03-20_23-52-32](https://cloud.githubusercontent.com/assets/7192950/6761480/353f40ac-cf5c-11e4-8501-f69c47164f8d.png)

It doesn't look as good as the separate dx texts, but I get the optimization. The question here whether such optimization will make a difference or not. What do you think?

I also added the convertNumber function which was missing, fixed a couple of variables typo.
